### PR TITLE
Feat/custome handler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "chromatrace"
-version = "0.2.15"
+version = "0.2.16"
 description = "Advanced Python logging with tracing, coloring and FastAPI, Django, and SocketIO integrations"
 readme = "README.md"
 authors = [

--- a/src/chromatrace/logging_config.py
+++ b/src/chromatrace/logging_config.py
@@ -40,12 +40,25 @@ class LoggingConfig:
         # Add handlers if they don't exist
         if not logger.handlers:
             self._setup_handlers(logger)
+            self._setup_custom_handlers(logger)
 
         return logger
 
+    def _setup_custom_handlers(self, logger: logging.Logger):
+        if not hasattr(self.settings, "custom_handlers"):
+            return
+
+        for handler in self.settings.custom_handlers:
+            if not isinstance(handler, logging.Handler):
+                continue
+            formatter = self._get_formatter(
+                colored=self.settings.use_console_colored_formatter
+            )
+            self._set_logger_settings(handler, formatter, logger)
+
     def _set_logger_settings(
         self,
-        handler: logging.handlers,
+        handler: logging.Handler,
         formatter: logging.Formatter,
         logger: logging.Logger,
     ):

--- a/src/chromatrace/logging_settings.py
+++ b/src/chromatrace/logging_settings.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Literal, Optional
 
 import click
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class LoggingSettings(BaseModel):
@@ -26,6 +26,7 @@ class LoggingSettings(BaseModel):
     use_syslog_colored_formatter: bool = False
     use_file_colored_formatter: bool = False
     show_process_id: bool = False
+    custom_handlers: list = Field(default_factory=list)
 
     def __init__(self, **data):
         super().__init__(**data)


### PR DESCRIPTION
This pull request introduces support for custom logging handlers in the `chromatrace` library, allowing users to extend logging functionality by specifying their own handlers. The changes also include a version bump and a minor type fix.

**Custom Logging Handlers Support:**

* Added a `custom_handlers` field to the `LoggingSettings` class, allowing users to specify a list of custom logging handlers.
* Implemented the `_setup_custom_handlers` method in `logging_config.py` to initialize and configure custom handlers when present in the settings.

**Other Changes:**

* Bumped the package version from `0.2.15` to `0.2.16` in `pyproject.toml`.
* Fixed the type annotation for the `handler` parameter in `_set_logger_settings` from `logging.handlers` to `logging.Handler`.
* Imported `Field` from `pydantic` to support the new field definition in `LoggingSettings`.